### PR TITLE
Use native `map`, `filter` for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
-from itertools import imap, ifilter
+try:
+    from itertools import imap, ifilter
+except ImportError:
+    imap = map
+    ifilter = filter
 from os import path
 from ast import parse
 


### PR DESCRIPTION
In Python 3, `imap` and `ifilter` are gone from `itertools`, and native `map` / `filter` are used instead.

see http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html#itertools

Thanks!
