### PR TITLE
avoid error on not finding path

### DIFF
--- a/gitim.py
+++ b/gitim.py
@@ -85,7 +85,7 @@ Version: {__version__}
 
         get_repos = g.get_organization(args.org).get_repos if args.org else g.get_user().get_repos
         for repo in get_repos():
-            if not path.exists(join(repo.name)):
+            if not path.exists(join(repo.full_name)):
                 clone_url = repo.clone_url
                 if args.ssh:
                     clone_url = repo.ssh_url
@@ -97,7 +97,7 @@ Version: {__version__}
                     call([u'git', u'clone', clone_url, join(repo.full_name)])
             elif not args.nopull:
                 print(u'Updating "{repo.name}"'.format(repo=repo))
-                call([u'git', u'pull'], env=dict(environ, GIT_DIR=join(repo.name, '.git').encode('utf8')))
+                call([u'git', u'pull'], env=dict(environ, GIT_DIR=join(repo.full_name, '.git').encode('utf8')))
             else:
                 print(u'Already cloned, skipping...\t"{repo.full_name}"'.format(repo=repo))
         print(u'FIN')

--- a/gitim.py
+++ b/gitim.py
@@ -50,6 +50,7 @@ Version: {__version__}
         parser.add_argument('--nopull', action='store_true', help=u'Don\'t pull if repository exists. [false]')
         parser.add_argument('--shallow', action='store_true', help=u'Perform shallow clone. [false]')
         parser.add_argument('--ssh', action='store_true', help=u'Use ssh+git urls for checkout. [false]')
+        parser.add_argument('--noforks', action='store_true', help=u'Skip forked repositories. [false]')
         return parser
 
     def make_github_agent(self, args):
@@ -85,7 +86,9 @@ Version: {__version__}
 
         get_repos = g.get_organization(args.org).get_repos if args.org else g.get_user().get_repos
         for repo in get_repos():
-            if not path.exists(join(repo.full_name)):
+            if args.noforks and repo.fork:
+                print(u'Repo "{repo.full_name}" is a fork, skipping'.format(repo=repo))
+            elif not path.exists(join(repo.full_name)):
                 clone_url = repo.clone_url
                 if args.ssh:
                     clone_url = repo.ssh_url

--- a/gitim.py
+++ b/gitim.py
@@ -89,6 +89,9 @@ Version: {__version__}
                 clone_url = repo.clone_url
                 if args.ssh:
                     clone_url = repo.ssh_url
+                elif not args.token:
+                    if user != "":
+                        clone_url = clone_url.replace("://github.com/","://"+user+"@github.com/")
                 if args.shallow:
                     print(u'Shallow cloning "{repo.full_name}"'.format(repo=repo))
                     call([u'git', u'clone', '--depth=1', clone_url, join(repo.full_name)])


### PR DESCRIPTION
Use full repo name always, to avoid fatal: destination path 'directory/anotheruser/repo' already exists and is not an empty directory.
when running gitim a second time on an already cloned repo from other user

Also, forward the username automatically to the clone url